### PR TITLE
Add support for multiple media entries

### DIFF
--- a/lib/plex-ruby/video.rb
+++ b/lib/plex-ruby/video.rb
@@ -1,11 +1,11 @@
 module Plex
   class Video
 
-    ATTRIBUTES = %w(ratingKey key studio type title titleSort contentRating summary 
-                    rating viewCount year tagline thumb art duration 
+    ATTRIBUTES = %w(ratingKey key studio type title titleSort contentRating summary
+                    rating viewCount year tagline thumb art duration
                     originallyAvailableAt updatedAt)
-      
-    attr_reader :media, :genres, :writers, :directors, :roles, :attribute_hash
+
+    attr_reader :medias, :genres, :writers, :directors, :roles, :attribute_hash
 
     # @param [Nokogiri::XML::Element] nokogiri element that represents this
     #   Video
@@ -18,11 +18,11 @@ module Plex
         end
       end
 
-      @media      = Plex::Media.new(node.search('Media').first)
+      @medias     = node.search('Media').map    { |m| Plex::Media.new(m)    }
       @genres     = node.search('Genre').map    { |m| Plex::Genre.new(m)    }
       @writers    = node.search('Writer').map   { |m| Plex::Writer.new(m)   }
-      @directors  = node.search('Director').map { |m| Plex::Director.new(m) } 
-      @roles      = node.search('Role').map     { |m| Plex::Role.new(m)     } 
+      @directors  = node.search('Director').map { |m| Plex::Director.new(m) }
+      @roles      = node.search('Role').map     { |m| Plex::Role.new(m)     }
     end
 
 

--- a/test/test_episode.rb
+++ b/test/test_episode.rb
@@ -23,8 +23,8 @@ describe Plex::Episode do
     (Plex::Video::ATTRIBUTES - %w(key)).map {|m| Plex.underscore(m) }.each { |method|
       @episode.send(method.to_sym).must_equal fake_video.send(method.to_sym)
     }
-    
-    @episode.media.must_equal fake_video.media
+
+    @episode.medias.must_equal fake_video.medias
 
     @episode.genres.must_equal fake_video.genres
 

--- a/test/test_movie.rb
+++ b/test/test_movie.rb
@@ -16,8 +16,8 @@ describe Plex::Movie do
     (Plex::Video::ATTRIBUTES - %w(key)).map {|m| Plex.underscore(m) }.each { |method|
       @movie.send(method.to_sym).must_equal fake_video.send(method.to_sym)
     }
-    
-    @movie.media.must_equal fake_video.media
+
+    @movie.medias.must_equal fake_video.medias
 
     @movie.genres.must_equal fake_video.genres
 

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -11,9 +11,9 @@ describe Plex::Video do
       @video.send(method.to_sym).must_equal FAKE_VIDEO_NODE_HASH[method.to_sym]
     end
   }
-  
+
   it "should correctly referance its media object" do
-    @video.instance_variable_get("@media").must_equal Plex::Media.new(FAKE_VIDEO_NODE_HASH[:Media])
+    @video.instance_variable_get("@medias").must_equal Array( Plex::Media.new(FAKE_VIDEO_NODE_HASH[:Media]) )
   end
 
   it "should correctly referance its genre objects" do


### PR DESCRIPTION
I added support for multiple media entries.

`Plex::Video` now contains `@medias` instead of `@media`. This closes #8.

Tests are updated as well.
