### PR TITLE
Add X-Plex-Token support to requests for remote calls

### DIFF
--- a/lib/plex-ruby/client.rb
+++ b/lib/plex-ruby/client.rb
@@ -1,10 +1,10 @@
 module Plex
   class Client
 
-    NAV_METHODS = %w(moveUp moveDown moveLeft moveRight pageUp pageDown nextLetter 
-                     previousLetter select back contextMenu toggleOSD) 
+    NAV_METHODS = %w(moveUp moveDown moveLeft moveRight pageUp pageDown nextLetter
+                     previousLetter select back contextMenu toggleOSD)
 
-    PLAYBACK_METHODS = %w(play pause stop rewind fastForward stepForward 
+    PLAYBACK_METHODS = %w(play pause stop rewind fastForward stepForward
                           bigStepForward stepBack bigStepBack skipNext skipPrevious)
 
     ATTRIBUTES = %w(name host address port machineIdentifier version)
@@ -30,7 +30,10 @@ module Plex
     NAV_METHODS.each { |nav|
       class_eval %(
         def #{Plex.underscore(nav)}
-          ping player_url+'/navigation/#{nav}'
+          url = player_url+'/navigation/#{nav}'
+          url += '?'+plex_token if plex_token
+
+          ping url
         end
       )
     }
@@ -43,13 +46,16 @@ module Plex
     PLAYBACK_METHODS.each { |playback|
       class_eval %(
         def #{Plex.underscore(playback)}
-          ping player_url+'/playback/#{playback}'
+          url = player_url+'/playback/#{playback}'
+          url += '?'+plex_token if plex_token
+
+          ping url
         end
       )
     }
 
     def play_file
-      ping player_url+"/application/playFile"
+      ping player_url+"/application/playFile?#{plex_token}"
     end
 
     # Plays a video that is in the library
@@ -64,7 +70,7 @@ module Plex
     def play_media(key, user_agent = nil, http_cookies = nil, view_offset = nil)
 
       if !key.is_a?(String) && key.respond_to?(:key)
-        key = key.key 
+        key = key.key
       end
 
       url = player_url+'/application/playMedia?'
@@ -73,6 +79,7 @@ module Plex
       url += "&userAgent=#{user_agent}" if user_agent
       url += "&httpCookies=#{http_cookies}" if http_cookies
       url += "&viewOffset=#{view_offset}" if view_offset
+      url += "&#{plex_token}" if plex_token
 
       ping url
     end
@@ -89,6 +96,7 @@ module Plex
       url += "width=#{width}"
       url += "&height=#{height}"
       url += "&quality=#{quality}"
+      url += "&#{plex_token}" if plex_token
 
       ping url
     end
@@ -99,7 +107,7 @@ module Plex
     # @return [True, nil] true if it worked, nil if something went wrong check
     #   the console for the error message
     def send_string(text)
-      ping player_url+"/application/sendString?text=#{CGI::escape(text.to_s)}"
+      ping player_url+"/application/sendString?text=#{CGI::escape(text.to_s)}&#{plex_token}"
     end
 
     # Sends a key code to the Plex Client.  Key codes represent key presses on
@@ -112,17 +120,22 @@ module Plex
     # @return [True, nil] true if it worked, nil if something went wrong check
     #   the console for the error message
     def send_key(code)
-      ping player_url+"/application/sendKey?code=#{CGI::escape(code.to_s)}"
+      ping player_url+"/application/sendKey?code=#{CGI::escape(code.to_s)}&#{plex_token}"
     end
 
     # (see #send_key)
     def send_virtual_key(code)
-      ping player_url+"/application/sendVirtualKey?code=#{CGI::escape(code.to_s)}"
+      ping player_url+"/application/sendVirtualKey?code=#{CGI::escape(code.to_s)}&#{plex_token}"
     end
 
     # @private
     def url #:nodoc:
       server.url
+    end
+
+    # @private
+    def plex_token #:nodoc:
+      server.plex_token
     end
 
     # @private

--- a/lib/plex-ruby/episode.rb
+++ b/lib/plex-ruby/episode.rb
@@ -14,7 +14,7 @@ module Plex
     def attribute_hash
       video.attribute_hash.merge({'key' => key})
     end
-    
+
     # Delegates all method calls to the video object that represents this
     # episode, if that video object responds to the method.
     def method_missing(method, *args, &block)
@@ -39,6 +39,11 @@ module Plex
     end
 
     # @private
+    def plex_token #:nodoc:
+      season.plex_token
+    end
+
+    # @private
     def ==(other) #:nodoc:
       if other.is_a? Plex::Episode
         key == other.key
@@ -55,7 +60,10 @@ module Plex
     private
 
     def xml_doc
-      @xml_doc ||= Nokogiri::XML( open(url+key) )
+      path = url+key
+      path += "?#{plex_token}" if plex_token
+
+      @xml_doc ||= Nokogiri::XML( open(path) )
     end
 
     def video

--- a/lib/plex-ruby/library.rb
+++ b/lib/plex-ruby/library.rb
@@ -44,6 +44,11 @@ module Plex
     end
 
     # @private
+    def plex_token #:nodoc:
+      server.plex_token
+    end
+
+    # @private
     def ==(other) #:nodoc:
       if other.is_a? Library
         server == other.server
@@ -73,7 +78,10 @@ module Plex
     end
 
     def base_doc
-      Nokogiri::XML( open(url+key) )
+      path = url+key
+      path += "?#{plex_token}" if plex_token
+
+      Nokogiri::XML( open(path) )
     end
 
 

--- a/lib/plex-ruby/movie.rb
+++ b/lib/plex-ruby/movie.rb
@@ -39,6 +39,11 @@ module Plex
     end
 
     # @private
+    def plex_token #:nodoc:
+      section.plex_token
+    end
+
+    # @private
     def inspect #:nodoc:
       "#<Plex::Movie: key=\"#{key}\" title=\"#{title}\">"
     end
@@ -46,7 +51,7 @@ module Plex
     private
 
     def xml_doc
-      @xml_doc ||= Nokogiri::XML( open(url+key) )
+      @xml_doc ||= Nokogiri::XML( open(url+key+"?#{plex_token}") )
     end
 
     def video

--- a/lib/plex-ruby/season.rb
+++ b/lib/plex-ruby/season.rb
@@ -2,8 +2,8 @@ module Plex
   # Found at /library/metadata/:key
   class Season
 
-    ATTRIBUTES = %w(ratingKey guid type title summary index thumb leafCount 
-                    viewedLeafCount addedAt updatedAt) 
+    ATTRIBUTES = %w(ratingKey guid type title summary index thumb leafCount
+                    viewedLeafCount addedAt updatedAt)
 
     attr_reader :show, :key, :attribute_hash
 
@@ -63,6 +63,11 @@ module Plex
     end
 
     # @private
+    def plex_token #:nodoc:
+      show.plex_token
+    end
+
+    # @private
     def ==(other) #:nodoc:
       if other.is_a? Plex::Season
         key == other.key
@@ -79,18 +84,18 @@ module Plex
     private
 
     def base_doc
-      Nokogiri::XML( open(url+key) )
+      Nokogiri::XML( open(url+key+"?#{plex_token}}") )
     end
 
     def base_children_doc
-      Nokogiri::XML( open(url+key+'/children') )
+      Nokogiri::XML( open(url+key+"/children?#{plex_token}") )
     end
 
     def xml_doc
       @xml_doc ||= base_doc
     end
 
-    def children 
+    def children
       @children ||= base_children_doc
     end
 

--- a/lib/plex-ruby/section.rb
+++ b/lib/plex-ruby/section.rb
@@ -25,7 +25,7 @@ module Plex
     end
 
 
-    # Returns a list of shows or movies that are in this Section. 
+    # Returns a list of shows or movies that are in this Section.
     #
     # all - all videos in this Section
     # unwatched - videos unwatched in this Section
@@ -38,7 +38,10 @@ module Plex
     GROUPS.each { |method|
       class_eval %(
         def #{Plex.underscore(method)}
-          Plex::Parser.new( self, Nokogiri::XML(open(url+key+'/#{method}')) ).parse
+          path = url+key+"/#{method}"
+          path += '?'+plex_token if plex_token
+
+          Plex::Parser.new( self, Nokogiri::XML(open(path)) ).parse
         end
       )
     }
@@ -51,7 +54,7 @@ module Plex
     #    by_#{category}(key) - all shows / movies by that key
     #
     # Example:
-    #     
+    #
     #     library.section(2).by_year(2008) # List of TV Shows from 2008
     #     library.section(1).by_first_character("H") # movies starting with 'H'
     #     library.section(2).genres # Array of Hashes explaining all of the genres
@@ -71,7 +74,10 @@ module Plex
           @#{Plex.underscore(method)}s = grab_keys('#{method}')
         end
         def by_#{Plex.underscore(method)}(val)
-          Plex::Parser.new( self, Nokogiri::XML(open(url+key+"/#{method}/\#{val}")) ).parse
+          path = url+key+"/#{method}/\#{val}"
+          path += '?'+plex_token if plex_token
+
+          Plex::Parser.new( self, Nokogiri::XML(open(path)) ).parse
         end
       )
     }
@@ -80,10 +86,15 @@ module Plex
     def key #:nodoc:
       "/library/sections/#{@key}"
     end
-    
+
     # @private
     def url #:nodoc:
       library.url
+    end
+
+    # @private
+    def plex_token #:nodoc:
+      library.plex_token
     end
 
     # @private
@@ -103,7 +114,7 @@ module Plex
     private
 
     def grab_keys(action)
-      Nokogiri::XML(open(url+key+"/#{action}")).search('Directory').map do |node| 
+      Nokogiri::XML(open(url+key+"/#{action}?#{plex_token}")).search('Directory').map do |node|
         {
           key: node.attr('key'),
           title: node.attr('title')

--- a/lib/plex-ruby/server.rb
+++ b/lib/plex-ruby/server.rb
@@ -1,11 +1,12 @@
 module Plex
   class Server
 
-    attr_reader :host, :port
+    attr_reader :host, :port, :auth
 
-    def initialize(host, port)
+    def initialize(host, port, auth = nil)
       @host = host
       @port = port
+      @auth = auth
     end
 
     # The library of this server
@@ -16,7 +17,7 @@ module Plex
     end
 
     # The Plex clients that are connected to this Server
-    # 
+    #
     # @return [Array] list of Clients connected to this server
     def clients
       @clients ||= search_clients clients_doc
@@ -33,14 +34,19 @@ module Plex
     end
 
     # @private
+    def plex_token #:nodoc:
+      "X-Plex-Token=#{auth}" if auth
+    end
+
+    # @private
     def inspect #:nodoc:
-      "#<Plex::Server: host=#{host} port=#{port}>"
+      "#<Plex::Server: host=#{host} port=#{port} auth=#{auth}>"
     end
 
     private
 
     def clients_base
-      Nokogiri::XML( open(url+'/clients') )
+      Nokogiri::XML( open(url+"/clients?#{plex_token}") )
     end
 
     def clients_doc

--- a/lib/plex-ruby/show.rb
+++ b/lib/plex-ruby/show.rb
@@ -1,8 +1,8 @@
 module Plex
   class Show
 
-    ATTRIBUTES = %w(ratingKey guid studio type title contentRating summary index 
-                    rating year thumb art leafCount viewedLeafCount addedAt 
+    ATTRIBUTES = %w(ratingKey guid studio type title contentRating summary index
+                    rating year thumb art leafCount viewedLeafCount addedAt
                     updatedAt)
 
     attr_reader :section, :key, :attribute_hash
@@ -44,7 +44,7 @@ module Plex
     end
 
     # Helper method for selecting the special Season of this show
-    # Season 0 is where Plex stores episodes that are not part of a 
+    # Season 0 is where Plex stores episodes that are not part of a
     # regular season. i.e. Christmas Specials
     #
     # @return [Season] season with index of 0
@@ -89,6 +89,11 @@ module Plex
     end
 
     # @private
+    def plex_token #:nodoc:
+      section.plex_token
+    end
+
+    # @private
     def ==(other) #:nodoc:
       if other.is_a? Plex::Show
         key == other.key
@@ -105,17 +110,17 @@ module Plex
     private
 
     def base_doc
-      Nokogiri::XML( open(url+key) )
+      Nokogiri::XML( open(url+key+"?#{plex_token}") )
     end
 
     def children_base
-      Nokogiri::XML( open(url+key+'/children') )
+      Nokogiri::XML( open(url+key+'/children'+"?#{plex_token}") )
     end
 
     def xml_doc
       @xml_doc ||= base_doc
     end
-    
+
     def children
       @children ||= children_base
     end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -15,27 +15,27 @@ describe Plex::Client do
   Plex::Client::NAV_METHODS.each { |method|
     it "should properly communicate its ##{Plex.underscore(method)} method" do
       assert @client.send(Plex.underscore(method).to_sym)
-      FakeWeb.last_request.path.must_equal "/system/players/#{@client.name}/navigation/#{method}"
+      FakeWeb.last_request.path.must_equal "/system/players/#{@client.name}/navigation/#{method}?X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     end
   }
 
   Plex::Client::PLAYBACK_METHODS.each { |method|
     it "should properly communicate its ##{Plex.underscore(method)} method" do
       assert @client.send(Plex.underscore(method).to_sym)
-      FakeWeb.last_request.path.must_equal "/system/players/#{@client.name}/playback/#{method}"
+      FakeWeb.last_request.path.must_equal "/system/players/#{@client.name}/playback/#{method}?X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     end
   }
 
   it "should properly commnicate its  #play_file method" do
     assert @client.play_file
-    FakeWeb.last_request.path.must_equal "/system/players/#{@client.name}/application/playFile"
+    FakeWeb.last_request.path.must_equal "/system/players/#{@client.name}/application/playFile?X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
   end
 
   it "should properly commnicate its  #play_media method" do
     key = '/metadata/10'
     assert @client.play_media(key)
     FakeWeb.last_request.path.must_equal(
-      "/system/players/#{@client.name}/application/playMedia?path=#{CGI::escape(@client.url+key)}&key=#{CGI::escape(key)}"
+      "/system/players/#{@client.name}/application/playMedia?path=#{CGI::escape(@client.url+key)}&key=#{CGI::escape(key)}&X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     )
   end
 
@@ -43,35 +43,35 @@ describe Plex::Client do
     object = Plex::Episode.new(FakeParent.new, '/libary/metadata/6')
     assert @client.play_media(object)
     FakeWeb.last_request.path.must_equal(
-      "/system/players/#{@client.name}/application/playMedia?path=#{CGI::escape(@client.url+object.key)}&key=#{CGI::escape(object.key)}"
+      "/system/players/#{@client.name}/application/playMedia?path=#{CGI::escape(@client.url+object.key)}&key=#{CGI::escape(object.key)}&X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     )
   end
 
   it "should properly commnicate its  #screenshot method" do
     assert @client.screenshot(100, 100, 75)
     FakeWeb.last_request.path.must_equal(
-      "/system/players/#{@client.name}/application/screenshot?width=100&height=100&quality=75"
+      "/system/players/#{@client.name}/application/screenshot?width=100&height=100&quality=75&X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     )
   end
 
   it "should properly commnicate its  #send_string method" do
     assert @client.send_string(35)
     FakeWeb.last_request.path.must_equal(
-      "/system/players/#{@client.name}/application/sendString?text=35"
+      "/system/players/#{@client.name}/application/sendString?text=35&X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     )
   end
 
   it "should properly commnicate its  #send_key method" do
     assert @client.send_key(70)
     FakeWeb.last_request.path.must_equal(
-      "/system/players/#{@client.name}/application/sendKey?code=70"
+      "/system/players/#{@client.name}/application/sendKey?code=70&X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     )
   end
 
   it "should properly commnicate its  #send_virtual_key method" do
     assert @client.send_virtual_key(70)
     FakeWeb.last_request.path.must_equal(
-      "/system/players/#{@client.name}/application/sendVirtualKey?code=70"
+      "/system/players/#{@client.name}/application/sendVirtualKey?code=70&X-Plex-Token=Q29qZELpx3UNxFLuqPHH"
     )
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,8 +25,8 @@ class FakeNode
   end
 
   def attributes
-    @hash.each_with_object({}) do |(key, val), obj| 
-      obj[Plex.camelize(key)] = FakeAttr.new(val) 
+    @hash.each_with_object({}) do |(key, val), obj|
+      obj[Plex.camelize(key)] = FakeAttr.new(val)
     end
   end
 
@@ -37,6 +37,10 @@ class FakeNode
 end
 
 class FakeParent
+
+  def plex_token
+    'X-Plex-Token=Q29qZELpx3UNxFLuqPHH'
+  end
 
   def url
     'http://localhost:32400'
@@ -167,27 +171,27 @@ FAKE_ROLE_NODE_HASH = {
 
 FAKE_VIDEO_NODE_HASH = {
   rating_key: '7',
-  key: '/library/7', 
-  studio: 'Six', 
-  type: 'movie', 
-  title: 'Men in Black (2011)', 
-  title_sort: 'Men in Black', 
-  content_rating: 'MA', 
-  summary: 'Two men fight the entire world!', 
-  rating: '9.9', 
-  view_count: '0', 
-  year: '2011', 
-  tagline: 'Fight the Power!', 
-  thumb: '/some/long/filename.jpg', 
-  art: '/some/other/long/filename.jpg', 
-  duration: '3400', 
-  originally_available_at: '324124', 
-  updated_at: '342214', 
+  key: '/library/7',
+  studio: 'Six',
+  type: 'movie',
+  title: 'Men in Black (2011)',
+  title_sort: 'Men in Black',
+  content_rating: 'MA',
+  summary: 'Two men fight the entire world!',
+  rating: '9.9',
+  view_count: '0',
+  year: '2011',
+  tagline: 'Fight the Power!',
+  thumb: '/some/long/filename.jpg',
+  art: '/some/other/long/filename.jpg',
+  duration: '3400',
+  originally_available_at: '324124',
+  updated_at: '342214',
   index: '1',
-  Media: FakeNode.new( FAKE_MEDIA_NODE_HASH ), 
-  Genre: FakeNode.new( FAKE_GENRE_NODE_HASH ), 
+  Media: FakeNode.new( FAKE_MEDIA_NODE_HASH ),
+  Genre: FakeNode.new( FAKE_GENRE_NODE_HASH ),
   Writer: FakeNode.new( FAKE_WRITER_NODE_HASH ),
-  Director: FakeNode.new( FAKE_DIRECTOR_NODE_HASH ), 
+  Director: FakeNode.new( FAKE_DIRECTOR_NODE_HASH ),
   Role: FakeNode.new( FAKE_ROLE_NODE_HASH )
 }
 


### PR DESCRIPTION
Hey guys,

I've had a fun couple of days figuring this out and working on this. So what happens is locally calls work fine, because Plex Media Server does not require authentication on a LAN. However, I'm trying to access data about my home PMS from Heroku. One option would be to pay for a static IP and whitelist the IP for authentication in the settings on PMS. Alternately, after a lot research (and I could not find much documentation on this) I found that if you append X-Plex-Token=AUTH_CODE to all requests PMS will authenticate.

Before merging in this would require some added documentation (such as how to get this code). I was able to get it by doing:

`curl -H "Content-Length: 0" -H "X-Plex-Client-Identifier: my-app" -u<user>:<password> -X POST https://my.plexapp.com/users/sign_in.xml
`

I have this working just fine on my personal site now via heroku command line, and I figured I would see if you guys wanted to merge it in upstream. Honestly this is my first time doing something this extensive with someone else's gem so let me know if I need to do anything else!
