### PR TITLE
Correct URI escape

### DIFF
--- a/lib/plex-ruby/client.rb
+++ b/lib/plex-ruby/client.rb
@@ -133,7 +133,7 @@ module Plex
     private
 
     def player_url
-      url+"/system/players/#{name}"
+      URI.escape(url+"/system/players/#{name}")
     end
 
     def ping(url)


### PR DESCRIPTION
Use URI escape to remove spaces from URL.